### PR TITLE
fix: Add complete V2 SKU support with automatic subnet delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,24 @@ cd azure-apim-bicep
 chmod +x apim.sh scripts/*.sh
 ```
 
+### ⚠️ Important: V2 SKU Requirements
+
+If using **V2 SKUs** (BasicV2, StandardV2, PremiumV2), be aware of the following:
+
+**Automatic Subnet Delegation** - When creating new subnets, the templates automatically handle delegation to `Microsoft.Web/serverFarms` (required for V2 SKUs).
+
+**Manual Delegation Required** - If using an **existing subnet** with V2 SKUs, you must manually delegate the subnet before deployment:
+
+```bash
+az network vnet subnet update \
+  --resource-group <vnet-resource-group> \
+  --vnet-name <vnet-name> \
+  --name <subnet-name> \
+  --delegations Microsoft.Web/serverFarms
+```
+
+For detailed information, see [docs/V2-SKU-SUBNET-DELEGATION.md](docs/V2-SKU-SUBNET-DELEGATION.md)
+
 ### Using the Unified CLI (Recommended)
 
 The project now includes a unified CLI interface (`apim.sh`) that provides a single entry point for all operations:

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -133,6 +133,7 @@ module vnet 'network/vnet.bicep' = if (!useExistingVnet) {
     vnetCidr: vnetCidr
     subnetName: subnetName
     subnetCidr: subnetCidr
+    apimSkuName: skuName
   }
 }
 
@@ -146,6 +147,7 @@ module newSubnetInExistingVnet 'network/cross-rg-subnet.bicep' = if (useExisting
     subnetName: subnetName
     subnetCidr: subnetCidr
     nsgResourceId: useExistingNsg ? existingResources.outputs.nsgResourceId : nsg.outputs.id
+    apimSkuName: skuName
   }
 }
 

--- a/bicep/network/cross-rg-subnet.bicep
+++ b/bicep/network/cross-rg-subnet.bicep
@@ -19,6 +19,9 @@ param subnetCidr string
 @description('Resource ID of the Network Security Group to associate with the subnet')
 param nsgResourceId string
 
+@description('APIM SKU name (used to determine if subnet delegation is needed)')
+param apimSkuName string
+
 // -------------------------------------------
 // Parse VNet Resource ID Components
 // -------------------------------------------
@@ -38,6 +41,7 @@ module subnetDeployment 'subnet-deployment.bicep' = {
     subnetName: subnetName
     subnetCidr: subnetCidr
     nsgResourceId: nsgResourceId
+    apimSkuName: apimSkuName
   }
 }
 

--- a/docs/V2-SKU-SUBNET-DELEGATION.md
+++ b/docs/V2-SKU-SUBNET-DELEGATION.md
@@ -1,0 +1,129 @@
+# APIM V2 SKU Subnet Delegation Requirements
+
+## Overview
+
+Azure API Management V2 SKUs (BasicV2, StandardV2, PremiumV2) require **subnet delegation** to `Microsoft.Web/serverFarms` for VNet integration. This is different from classic SKUs which use traditional VNet integration.
+
+## Automatic Delegation
+
+The Bicep templates in this repository automatically handle subnet delegation for V2 SKUs when:
+
+1. **Creating a new VNet and subnet** - The [vnet.bicep](../bicep/network/vnet.bicep) module automatically adds delegation for V2 SKUs
+2. **Creating a new subnet in an existing VNet** - The [cross-rg-subnet.bicep](../bicep/network/cross-rg-subnet.bicep) module automatically adds delegation for V2 SKUs
+
+## Manual Delegation Required
+
+If you are **using an existing subnet** (`USE_EXISTING_SUBNET=true`), you must manually delegate the subnet before deployment.
+
+### Option 1: Azure Portal
+
+1. Navigate to your Virtual Network in the Azure Portal
+2. Select **Subnets** from the left menu
+3. Click on the subnet you want to use for APIM
+4. Under **Subnet delegation**, select **Microsoft.Web/serverFarms**
+5. Click **Save**
+
+### Option 2: Azure CLI
+
+```bash
+# Set your variables
+SUBSCRIPTION_ID="your-subscription-id"
+RESOURCE_GROUP="your-vnet-resource-group"
+VNET_NAME="your-vnet-name"
+SUBNET_NAME="your-subnet-name"
+
+# Add subnet delegation
+az network vnet subnet update \
+  --subscription "$SUBSCRIPTION_ID" \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name "$SUBNET_NAME" \
+  --delegations Microsoft.Web/serverFarms
+```
+
+### Option 3: PowerShell
+
+```powershell
+# Set your variables
+$subscriptionId = "your-subscription-id"
+$resourceGroup = "your-vnet-resource-group"
+$vnetName = "your-vnet-name"
+$subnetName = "your-subnet-name"
+
+# Set context
+Set-AzContext -SubscriptionId $subscriptionId
+
+# Get the subnet
+$vnet = Get-AzVirtualNetwork -ResourceGroupName $resourceGroup -Name $vnetName
+$subnet = Get-AzVirtualNetworkSubnetConfig -VirtualNetwork $vnet -Name $subnetName
+
+# Add delegation
+$delegation = New-AzDelegation -Name "apim-delegation" -ServiceName "Microsoft.Web/serverFarms"
+$subnet.Delegations.Add($delegation)
+
+# Update the subnet
+Set-AzVirtualNetworkSubnetConfig -VirtualNetwork $vnet -Name $subnetName `
+  -AddressPrefix $subnet.AddressPrefix `
+  -Delegation $delegation | Set-AzVirtualNetwork
+```
+
+## Deployment Error Reference
+
+If you see this error during deployment:
+
+```
+{
+  "code": "VirtualNetworkSubnetHasIncorrectDelegation",
+  "message": "API Management service V2 outbound Virtual Network integration with SubnetId ...
+              requires subnet to be delegated to Microsoft.Web/serverFarms.
+              Please refer to https://aka.ms/apim-vnet-outbound for more details."
+}
+```
+
+This means:
+- You are deploying a V2 SKU (BasicV2, StandardV2, or PremiumV2)
+- You are using an existing subnet
+- The subnet is not delegated to `Microsoft.Web/serverFarms`
+
+**Solution**: Manually delegate the subnet using one of the methods above, then retry the deployment.
+
+## SKU-Specific Behavior
+
+| SKU | VNet Support | Delegation Required |
+|-----|-------------|-------------------|
+| Developer | ❌ No | N/A |
+| Basic | ❌ No | N/A |
+| Standard | ❌ No | N/A |
+| Premium | ✅ Yes | ❌ No (Classic VNet Integration) |
+| BasicV2 | ✅ Yes | ✅ Yes (Microsoft.Web/serverFarms) |
+| StandardV2 | ✅ Yes | ✅ Yes (Microsoft.Web/serverFarms) |
+| PremiumV2 | ✅ Yes | ✅ Yes (Microsoft.Web/serverFarms) |
+
+## Validation
+
+To verify subnet delegation, use:
+
+```bash
+az network vnet subnet show \
+  --subscription "$SUBSCRIPTION_ID" \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name "$SUBNET_NAME" \
+  --query delegations
+```
+
+Expected output for V2 SKUs:
+```json
+[
+  {
+    "name": "apim-delegation",
+    "serviceName": "Microsoft.Web/serverFarms",
+    ...
+  }
+]
+```
+
+## Additional Resources
+
+- [Azure APIM VNet Integration Documentation](https://aka.ms/apim-vnet-outbound)
+- [Azure Subnet Delegation Overview](https://docs.microsoft.com/azure/virtual-network/subnet-delegation-overview)

--- a/scripts/validate-config.sh
+++ b/scripts/validate-config.sh
@@ -381,6 +381,14 @@ validate_network_reuse_config() {
             pass "Will reuse existing subnet in VNet"
             if [[ -n "${SUBNET_NAME:-}" ]]; then
                 pass "Existing subnet name provided: ${SUBNET_NAME}"
+
+                # Check for V2 SKU delegation requirement
+                if [[ "${SKU_NAME:-}" =~ V2$ ]]; then
+                    warn "V2 SKU detected: Existing subnet must be delegated to Microsoft.Web/serverFarms"
+                    echo "  To delegate the subnet, run:"
+                    echo "  az network vnet subnet update --resource-group <rg> --vnet-name <vnet> --name ${SUBNET_NAME} --delegations Microsoft.Web/serverFarms"
+                    echo "  See docs/V2-SKU-SUBNET-DELEGATION.md for details"
+                fi
             else
                 fail "USE_EXISTING_SUBNET=true but no subnet name provided"
             fi
@@ -464,11 +472,11 @@ validate_environment_config() {
     
     if [[ -n "${SKU_NAME:-}" ]]; then
         case "$SKU_NAME" in
-            "Developer"|"Basic"|"Standard"|"Premium")
+            "Developer"|"Basic"|"Standard"|"Premium"|"BasicV2"|"StandardV2"|"PremiumV2")
                 pass "SKU name is valid: $SKU_NAME"
                 ;;
             *)
-                fail "Invalid SKU name: $SKU_NAME (must be Developer, Basic, Standard, or Premium)"
+                fail "Invalid SKU name: $SKU_NAME (must be Developer, Basic, Standard, Premium, BasicV2, StandardV2, or PremiumV2)"
                 ;;
         esac
     fi


### PR DESCRIPTION
This commit resolves multiple issues related to Azure APIM V2 SKUs (BasicV2, StandardV2, PremiumV2) and implements automatic subnet delegation required for V2 VNet integration.

Issues Fixed:
- Validation script rejected V2 SKU names (only accepted classic SKUs)
- Interactive setup crashed with "unbound variable" error after capacity selection
- Bicep templates applied VNet config to non-supporting SKUs (Developer/Basic/Standard)
- V2 deployments failed with "VirtualNetworkSubnetHasIncorrectDelegation" error
- Missing subnet delegation to Microsoft.Web/serverFarms for V2 SKUs

Changes:

Bicep Templates:
- apim/apim-service.bicep: Made VNet configuration SKU-aware, only apply to Premium and V2 SKUs that support VNet integration
- network/vnet.bicep: Added automatic subnet delegation for V2 SKUs
- network/subnet-deployment.bicep: Added delegation support for V2 SKUs
- network/cross-rg-subnet.bicep: Pass SKU parameter to subnet module
- main.bicep: Pass SKU name to network modules for delegation logic

Scripts:
- validate-config.sh: Added V2 SKU validation (BasicV2/StandardV2/PremiumV2) and delegation requirement warnings for existing subnets
- setup-environment.sh: Fixed unbound variable error, added V2 subnet delegation warnings with CLI commands during interactive setup

Documentation:
- README.md: Added V2 SKU requirements section with delegation quick start
- docs/V2-SKU-SUBNET-DELEGATION.md: NEW - Comprehensive guide covering automatic vs manual delegation, Portal/CLI/PowerShell instructions, error troubleshooting, and SKU comparison table

Impact:
- V2 SKU deployments now succeed automatically when creating new subnets
- Clear guidance provided for existing subnet scenarios
- Backward compatible with classic SKUs (Developer/Basic/Standard/Premium)
- Enhanced validation and setup experience with helpful warnings

Ref: https://aka.ms/apim-vnet-outbound