### PR TITLE
fix: Skip gateway associations for V2 SKUs to prevent API deployment …

### DIFF
--- a/bicep/apis/api-template.bicep
+++ b/bicep/apis/api-template.bicep
@@ -79,9 +79,11 @@ resource apiProducts 'Microsoft.ApiManagement/service/products/apis@2021-08-01' 
 
 // -------------------------------------------
 // Associate the API with one or more gateways
+// Note: V2 SKUs (BasicV2, StandardV2, PremiumV2) do not support gateway associations
+// APIs are automatically available on the built-in gateway for V2 SKUs
 // -------------------------------------------
 @batchSize(1)
-resource apiGateways 'Microsoft.ApiManagement/service/gateways/apis@2021-08-01' = [for gatewayName in gatewayNames: {
+resource apiGateways 'Microsoft.ApiManagement/service/gateways/apis@2021-08-01' = [for gatewayName in gatewayNames: if (length(gatewayNames) > 0) {
   name: '${apimName}/${gatewayName}/${apiId}'
   dependsOn: [
     api


### PR DESCRIPTION
…failures

V2 SKUs (BasicV2, StandardV2, PremiumV2) in Azure APIM don't support explicit gateway associations via the Microsoft.ApiManagement/service/gateways/apis resource type. APIs are automatically available on the built-in gateway for V2 SKUs, so attempting to create gateway associations causes deployments to fail.

Changes:
- Add V2 SKU detection in deploy-apis.sh and sync-apis.sh using SKU_NAME pattern matching
- Automatically override gatewayNames parameter to empty array when V2 SKU is detected
- Update Bicep template to conditionally create gateway associations only when array is not empty
- Add debug/verbose logging to track when gateway associations are skipped
- Document V2 SKU behavior in Bicep template comments

This fix enables successful API deployments to V2 SKU APIM instances while maintaining backward compatibility with classic SKUs (Developer, Basic, Standard, Premium).